### PR TITLE
Add features to eosio.forum (extend/cancel/RAM payer)

### DIFF
--- a/contracts/eosio.forum/include/forum.hpp
+++ b/contracts/eosio.forum/include/forum.hpp
@@ -76,7 +76,7 @@ class [[eosio::contract("forum")]] forum : public eosio::contract {
         void cancel(
             const name proposer,
             const name proposal_name,
-            uint64_t max_count
+            const uint64_t max_count
         );
 
     private:

--- a/contracts/eosio.forum/include/forum.hpp
+++ b/contracts/eosio.forum/include/forum.hpp
@@ -72,6 +72,13 @@ class [[eosio::contract("forum")]] forum : public eosio::contract {
             const time_point_sec expires_at
         );
 
+        [[eosio::action]]
+        void cancel(
+            const name proposer,
+            const name proposal_name,
+            uint64_t max_count
+        );
+
     private:
         // 3 days in seconds (Computation: 3 days * 24 hours * 60 minutes * 60 seconds)
         constexpr static uint32_t FREEZE_PERIOD_IN_SECONDS = 3 * 24 * 60 * 60;

--- a/contracts/eosio.forum/include/forum.hpp
+++ b/contracts/eosio.forum/include/forum.hpp
@@ -65,6 +65,13 @@ class [[eosio::contract("forum")]] forum : public eosio::contract {
         [[eosio::action]]
         void status(const name account, const string& content);
 
+        [[eosio::action]]
+        void extend(
+            const name proposer,
+            const name proposal_name,
+            const time_point_sec expires_at
+        );
+
     private:
         // 3 days in seconds (Computation: 3 days * 24 hours * 60 minutes * 60 seconds)
         constexpr static uint32_t FREEZE_PERIOD_IN_SECONDS = 3 * 24 * 60 * 60;

--- a/contracts/eosio.forum/resources/forum.contracts.md
+++ b/contracts/eosio.forum/resources/forum.contracts.md
@@ -92,3 +92,14 @@ If I, {{ voter }}, am registered as a proxy and am casting votes on behalf of ot
 
 I, {{ voter }}, stipulate I have not and will not accept anything of value in exchange for this `vote`, on penalty of confiscation of these tokens, and other penalties.
 
+<h1 class="contract">extend</h1>
+
+## Description
+
+`extend` is used to extend the {{ expires_at }} timestamp value of a {{ proposal_name }} authorized by the {{ proposer }}.
+
+<h1 class="contract">cancel</h1>
+
+## Description
+
+`cancel` is used to cancel a {{ proposal_name }} authorized by the {{ proposer }}.

--- a/contracts/eosio.forum/src/forum.cpp
+++ b/contracts/eosio.forum/src/forum.cpp
@@ -222,7 +222,7 @@ void forum::cancel(const name proposer, const name proposal_name, uint64_t max_c
     proposals proposal_table(_self, _self.value);
 
     auto itr = proposal_table.find(proposal_name.value);
-    check(itr == proposal_table.end(), "proposal does not exist");
+    check(itr != proposal_table.end(), "proposal does not exist");
 
     votes vote_table(_self, _self.value);
     auto index = vote_table.template get_index<"byproposal"_n>();

--- a/contracts/eosio.forum/src/forum.cpp
+++ b/contracts/eosio.forum/src/forum.cpp
@@ -227,7 +227,7 @@ void forum::cancel(const name proposer, const name proposal_name, const uint64_t
     check(itr != proposal_table.end(), "proposal does not exist");
 
     // Enforce `max_count` to be high enough to prevent vote manipulation using the of cancel action
-    check( max_count <= 500, "max_count must be equal or greater than 500");
+    check( max_count >= 500, "max_count must be equal or greater than 500");
 
     votes vote_table(_self, _self.value);
     auto index = vote_table.template get_index<"byproposal"_n>();

--- a/contracts/eosio.forum/src/forum.cpp
+++ b/contracts/eosio.forum/src/forum.cpp
@@ -30,7 +30,7 @@ void forum::propose(
     proposals proposal_table(_self, _self.value);
     check(proposal_table.find(proposal_name.value) == proposal_table.end(), "proposal with same name already exists.");
 
-    proposal_table.emplace(proposer, [&](auto& row) {
+    proposal_table.emplace(_self, [&](auto& row) {
         row.proposal_name = proposal_name;
         row.proposer = proposer;
         row.title = title;
@@ -50,7 +50,7 @@ void forum::expire(const name proposal_name) {
     auto proposer = itr->proposer;
     require_auth(proposer);
 
-    proposal_table.modify(itr, proposer, [&](auto& row) {
+    proposal_table.modify(itr, eosio::same_payer, [&](auto& row) {
         row.expires_at = current_time_point_sec();
     });
 }
@@ -253,13 +253,13 @@ void forum::update_status(
 ) {
     auto itr = status_table.find(account.value);
     if (itr == status_table.end()) {
-        status_table.emplace(account, [&](auto& row) {
+        status_table.emplace(_self, [&](auto& row) {
             row.account = account;
             row.updated_at = current_time_point_sec();
             updater(row);
         });
     } else {
-        status_table.modify(itr, account, [&](auto& row) {
+        status_table.modify(itr, eosio::same_payer, [&](auto& row) {
             row.updated_at = current_time_point_sec();
             updater(row);
         });
@@ -277,7 +277,7 @@ void forum::update_vote(
 
     auto itr = index.find(vote_key);
     if (itr == index.end()) {
-        vote_table.emplace(voter, [&](auto& row) {
+        vote_table.emplace(_self, [&](auto& row) {
             row.id = vote_table.available_primary_key();
             row.proposal_name = proposal_name;
             row.voter = voter;
@@ -285,7 +285,7 @@ void forum::update_vote(
             updater(row);
         });
     } else {
-        index.modify(itr, voter, [&](auto& row) {
+        index.modify(itr, eosio::same_payer, [&](auto& row) {
             row.updated_at = current_time_point_sec();
             updater(row);
         });

--- a/contracts/eosio.forum/src/forum.cpp
+++ b/contracts/eosio.forum/src/forum.cpp
@@ -204,6 +204,7 @@ void forum::extend(
     proposals proposal_table(_self, _self.value);
     auto proposal_itr = proposal_table.find( proposal_name.value );
     check( proposal_itr != proposal_table.end(), "Could not find proposal with that name" );
+    check( expires_at > proposal_itr->expires_at, "expires_at must be greater than current expiry.");
 
     // Modify `proposals` table with lock boolean (true/false)
     proposal_table.modify(proposal_itr, eosio::same_payer, [&](auto & row) {


### PR DESCRIPTION
- [x] `extend` is used to extend the {{ expires_at }} timestamp value of a {{ proposal_name }} authorized by the {{ proposer }}.
- [x] `cancel` is used to cancel a {{ proposal_name }} authorized by the {{ proposer }}.
- [x] Set RAM payer as `eosio.forum` (_self) smart contract to all actions instead of users.

## Testing

Deployed on BOS Testnet under `eosforumdapp`

https://bos-test.eosx.io/tools/contract?contractAccount=eosforumdapp

### Test - RAM payer when voting

https://bos-test.eosx.io/tx/11881d71b42542738e8345f304683331eb32843e9d8a6c761a2ff45e1dc2fba5?listView=traces

<img width="722" alt="Screen Shot 2019-06-06 at 8 54 54 PM" src="https://user-images.githubusercontent.com/550895/59080410-6d822700-889d-11e9-9c57-a0a27fef22fc.png">

### Test - `extend` proposal time as proposer

- [x] only authorized user
- [x] update `proposal` table data
- [x] cannot extend shorter timeline

https://bos-test.eosx.io/tx/f59b72335de82a71c0f663badda42854199fa347edd6f30f3828afed96244000?listView=traces

### Test - `cancel` remove proposal & votes

- [x] removes proposal & vote from tables
- [x] removes votes before removing proposal
- [x] Enforce `max_count` to be high enough to prevent vote manipulation using the of cancel action

https://bos-test.eosx.io/tx/d9a3baedbc4a42ef7bdf3e9a708fd446583464e62fce0d2a8353e6767501e9d0?listView=traces