### PR TITLE
Add enhancements to auditor.bos (voter_info.staked & lower vote quorum)

### DIFF
--- a/contracts/auditor.bos/include/auditorbos.hpp
+++ b/contracts/auditor.bos/include/auditorbos.hpp
@@ -4,6 +4,7 @@
 #include <eosiolib/time.hpp>
 
 #include "external_types.hpp"
+#include "voter_info.hpp"
 
 #define _STRINGIZE(x) #x
 #define STRINGIZE(x) _STRINGIZE(x)
@@ -206,6 +207,7 @@ private: // Variables used throughout the other actions.
     votes_table votes_cast_by_members;
     bios_table candidate_bios;
     contr_state _currentState;
+    voter_table _voters;
 
 public:
 
@@ -215,7 +217,8 @@ public:
             votes_cast_by_members(_self, _self.value),
             candidate_bios(_self, _self.value),
             config_singleton(_self, _self.value),
-            contract_state(_self, _self.value) {
+            contract_state(_self, _self.value),
+            _voters( "eosio"_n, "eosio"_n.value ) {
 
         _currentState = contract_state.get_or_default(contr_state());
     }

--- a/contracts/auditor.bos/include/voter_info.hpp
+++ b/contracts/auditor.bos/include/voter_info.hpp
@@ -1,0 +1,35 @@
+struct [[eosio::table, eosio::contract("eosio.system")]] voter_info {
+    name                owner;     /// the voter
+    name                proxy;     /// the proxy set by the voter, if any
+    std::vector<name>   producers; /// the producers approved by this voter if no proxy set
+    int64_t             staked = 0;
+
+    /**
+     *  Every time a vote is cast we must first "undo" the last vote weight, before casting the
+     *  new vote weight.  Vote weight is calculated as:
+     *
+     *  stated.amount * 2 ^ ( weeks_since_launch/weeks_per_year)
+     */
+    double              last_vote_weight = 0; /// the vote weight cast the last time the vote was updated
+
+    /**
+     * Total vote weight delegated to this voter.
+     */
+    double              proxied_vote_weight= 0; /// the total vote weight delegated to this voter as a proxy
+    bool                is_proxy = 0; /// whether the voter is a proxy for others
+
+
+    uint32_t            flags1 = 0;
+    uint32_t            reserved2 = 0;
+    eosio::asset        reserved3;
+
+    uint64_t primary_key()const { return owner.value; }
+
+    enum class flags1_fields : uint32_t {
+        ram_managed = 1,
+        net_managed = 2,
+        cpu_managed = 4
+    };
+};
+
+typedef eosio::multi_index<"voters"_n, voter_info> voter_table;

--- a/contracts/auditor.bos/src/privatehelpers.cpp
+++ b/contracts/auditor.bos/src/privatehelpers.cpp
@@ -34,8 +34,6 @@ void auditorbos::modifyVoteWeights(name voter, vector<name> newVotes) {
     // This could be optimised with set diffing to avoid remove then add for unchanged votes. - later
     eosio::print("Modify vote weights: ", voter, "\n");
 
-    check( is_account( voter ), "voter account does not exist" );
-
     // To track previous votes weights
     int64_t old_weight = 0;
     vector<name> oldVotes = {};

--- a/contracts/auditor.bos/src/privatehelpers.cpp
+++ b/contracts/auditor.bos/src/privatehelpers.cpp
@@ -40,13 +40,13 @@ void auditorbos::modifyVoteWeights(name voter, vector<name> newVotes) {
 
     // Find voter's voting info
     auto voters_itr = _voters.find(voter.value);
-    check(voters_itr != _voters.end(), "voter must be voting for any number of block producers or a proxy");
+    check(voters_itr != _voters.end(), "ERR::VOTEAUDITOR_INVALID_VOTER_INFO::voter must be voting for any number of block producers or a proxy");
 
     // Get voter's staked weight
     int64_t vote_weight = voters_itr->staked;
 
     // Prevent voters with 0 staked balance from voting
-    check(vote_weight > 0, "voter must have a staked balance");
+    check(vote_weight > 0, "ERR::VOTEAUDITOR_INVALID_STAKE::voter must have a staked balance");
 
     // Find a vote that has been cast by this voter previously.
     auto existingVote = votes_cast_by_members.find(voter.value);

--- a/contracts/auditor.bos/src/voting.cpp
+++ b/contracts/auditor.bos/src/voting.cpp
@@ -19,19 +19,13 @@ void auditorbos::voteauditor(name voter, vector<name> newvotes) {
 
 
 void auditorbos::refreshvote(name voter) {
-    // Anyone can refresh vote
+    // any account can refresh vote
     // background processes will typically execute this action
-
-    // if (configs().authaccount == name{0}) {
-    //     require_auth(_self);
-    // } else {
-    //     require_auth(configs().authaccount);
-    // }
 
     // Find a vote that has been cast by this voter previously.
     auto existingVote = votes_cast_by_members.find(voter.value);
-    if (existingVote != votes_cast_by_members.end()) {
-        //new votes is same as old votes, will just apply the deltas
-        modifyVoteWeights(voter, existingVote->candidates);
-    }
+    check( existingVote != votes_cast_by_members.end(), "ERR::VOTEAUDITOR_VOTER_NOT_FOUND::Voter could not be found.");
+
+    // new votes is same as old votes, will just apply the deltas
+    modifyVoteWeights(voter, existingVote->candidates);
 }


### PR DESCRIPTION
- [x] Lower vote quorum to allow minimum auditor voting threshold to be 1M BOS
> Divide `uint32_t` by 10 to add an extra decimal which allows for lower vote quorum threshold.
- [x] Replace `delband` in favour of `voter_info.staked` as voting weights
- [x] add check for `refreshvote`
- [x] rename `max_supply` => `active_supply`