### PR TITLE
Feature/tally auditor

### DIFF
--- a/vote-tally/.env.example
+++ b/vote-tally/.env.example
@@ -2,6 +2,7 @@
 CHAIN="bos"
 NODEOS_ENDPOINT="https://bos.eosn.io"
 CONTRACT_FORUM="eosio.forum"
+CONTRACT_AUDITOR="auditor.bos"
 CONTRACT_TOKEN="eosio.token"
 TOKEN_SYMBOL="BOS"
 

--- a/vote-tally/README.md
+++ b/vote-tally/README.md
@@ -55,23 +55,35 @@ bosc forum propose [proposer] [proposal_name] [title] [proposal_expiration_date]
 
 ### `referendum` (tally)
 
-`referendum::tallies` (tallies for `eosio.forum` voters)
+`referendum::forum.tallies` (tallies for `eosio.forum` voters)
 
-- https://s3.amazonaws.com/bos.referendum/referendum/tallies/latest.json
+- https://s3.amazonaws.com/bos.referendum/referendum/forum.tallies/latest.json
 
-`referendum::accounts` (account details for `eosio.forum` voters)
+`referendum::forum.accounts` (account details for `eosio.forum` voters)
 
-- https://s3.amazonaws.com/bos.referendum/referendum/accounts/latest.json
+- https://s3.amazonaws.com/bos.referendum/referendum/forum.accounts/latest.json
 
-`referendum::proxies` (proxies details for `eosio.forum` voters)
+`referendum::forum.proxies` (proxies details for `eosio.forum` voters)
 
-- https://s3.amazonaws.com/bos.referendum/referendum/proxies/latest.json
+- https://s3.amazonaws.com/bos.referendum/referendum/forum.proxies/latest.json
 
-`referendum::delband` (self delegated bandwidth amount for all `eosio.forum` voters)
+`referendum::auditor.tallies` (tallies for `auditor.bos` voters)
+
+- https://s3.amazonaws.com/bos.referendum/referendum/auditor.tallies/latest.json
+
+`referendum::auditor.accounts` (account details for `auditor.bos` voters)
+
+- https://s3.amazonaws.com/bos.referendum/referendum/auditor.accounts/latest.json
+
+`referendum::auditor.proxies` (proxies details for `auditor.bos` voters)
+
+- https://s3.amazonaws.com/bos.referendum/referendum/auditor.proxies/latest.json
+
+`referendum::delband` (self delegated bandwidth amount for all `eosio.forum` & `auditor.bos` voters)
 
 - https://s3.amazonaws.com/bos.referendum/referendum/delband/latest.json
 
-`referendum::voters` (voters table for all `eosio.forum` voters)
+`referendum::voters` (voters table for all `eosio.forum` & `auditor.bos` voters)
 
 - https://s3.amazonaws.com/bos.referendum/referendum/voters/latest.json
 

--- a/vote-tally/index.ts
+++ b/vote-tally/index.ts
@@ -42,9 +42,8 @@ async function syncEosio(head_block_num: number) {
 
     // fetch `eosio` voters
     let eosioVoters: EosioVoter[] = [];
-    // if (DEBUG && fs.existsSync(voters_latest)) eosioVoters = load.sync(voters_latest) // Speed up download of eosio::voters table for debugging
-    // else
-    eosioVoters = await get_table_voters();
+    if (DEBUG && fs.existsSync(voters_latest)) eosioVoters = load.sync(voters_latest) // Speed up download of eosio::voters table for debugging
+    else eosioVoters = await get_table_voters();
 
     voters = filterVotersByVotes(eosioVoters, forum_votes, auditor_votes);
     voters_owner = new Set(voters.map((row) => row.owner));

--- a/vote-tally/index.ts
+++ b/vote-tally/index.ts
@@ -4,29 +4,35 @@ import * as write from "write-json-file";
 import * as load from "load-json-file";
 import { CronJob } from "cron";
 import { uploadS3 } from "./src/aws";
-import { ForumVote, Proposal, Voters, Delband, AuditorVotes } from "./src/interfaces";
+import { ForumVote, ForumProposal, EosioVoter, EosioDelband, AuditorVote, AuditorCandidate } from "./src/interfaces";
 import { rpc, CHAIN, CONTRACT_FORUM, DEBUG, CONTRACT_TOKEN, TOKEN_SYMBOL, CONTRACT_AUDITOR } from "./src/config";
-import { filterVotersByVotes, generateAccounts, generateProxies, generateTallies } from "./src/tallies";
-import { get_table_voters, get_forum_vote, get_table_proposal, get_table_delband, get_auditor_votes } from "./src/get_tables";
+import { generateForumAccounts, generateForumProxies, generateForumTallies } from "./src/tallies_forum";
+import { filterVotersByVotes } from "./src/tallies";
+import { get_table_voters, get_forum_vote, get_table_forum_proposal, get_table_delband, get_auditor_votes, get_table_auditor_candidates } from "./src/get_tables";
 import { disjoint, parseTokenString, createHash } from "./src/utils";
 import { generateEosioStats } from "./src/stats";
+import { generateAuditorAccounts, generateAuditorTallies, generateAuditorProxies } from "./src/tallies_auditor";
 
 // Base filepaths
 const basepath = path.join(__dirname, "data", CHAIN);
 const voters_latest = path.join(basepath, "eosio", "voters", "latest.json");
-const delband_latest = path.join(basepath, "eosio", "delband", "latest.json");
 
-// Global containers
-let forum_votes: ForumVote[] = [];
-let auditor_votes: AuditorVotes[] = [];
-let voters: Voters[] = [];
-
-// `eosioVoters` cannot be stored globaly since it will cause memory leaks
-let proposals: Proposal[] = [];
-let votes_owner: Set<string> = new Set();
-let voters_owner: Set<string> = new Set();
-let delband: Delband[] = [];
+// Global Eosio
 let currency_supply: any = null;
+
+// Global Referendum
+let voters: EosioVoter[] = [];
+let delband: EosioDelband[] = [];
+let voters_owner: Set<string> = new Set();
+let votes_owner: Set<string> = new Set();
+
+// Global Forum
+let forum_votes: ForumVote[] = [];
+let forum_proposals: ForumProposal[] = [];
+
+// Global Auditor
+let auditor_votes: AuditorVote[] = [];
+let auditor_candidates: AuditorCandidate[] = [];
 
 /**
  * Sync `eosio` tables
@@ -35,11 +41,11 @@ async function syncEosio(head_block_num: number) {
     console.log(`syncEosio [head_block_num=${head_block_num}]`)
 
     // fetch `eosio` voters
-    let eosioVoters: Voters[] = [];
+    let eosioVoters: EosioVoter[] = [];
     if (DEBUG && fs.existsSync(voters_latest)) eosioVoters = load.sync(voters_latest) // Speed up download of eosio::voters table for debugging
     else eosioVoters = await get_table_voters();
 
-    voters = filterVotersByVotes(eosioVoters, forum_votes);
+    voters = filterVotersByVotes(eosioVoters, forum_votes, auditor_votes);
     voters_owner = new Set(voters.map((row) => row.owner));
 
     // Retrieve `staked` from accounts that have not yet voted for BPs
@@ -70,14 +76,18 @@ async function syncForum(head_block_num: number) {
 
     // fetch `eosio.forum` votes
     forum_votes = await get_forum_vote();
-    votes_owner = new Set(forum_votes.map((row) => row.voter));
+
+    // Add unique voters to global tracking
+    for (const {voter} of forum_votes) {
+        votes_owner.add(voter);
+    }
 
     // fetch `eosio.forum` proposal
-    proposals = await get_table_proposal();
+    forum_proposals = await get_table_forum_proposal();
 
     // Save JSON
     save(CONTRACT_FORUM, "vote", head_block_num, forum_votes);
-    save(CONTRACT_FORUM, "proposal", head_block_num, proposals);
+    save(CONTRACT_FORUM, "proposal", head_block_num, forum_proposals);
 }
 
 /**
@@ -88,10 +98,18 @@ async function syncAuditor(head_block_num: number) {
 
     // fetch `auditor.bos` votes
     auditor_votes = await get_auditor_votes();
-    votes_owner = new Set(auditor_votes.map((row) => row.voter));
+
+    // Add unique voters to global tracking
+    for (const {voter} of auditor_votes) {
+        votes_owner.add(voter);
+    }
+
+    // fetch `eosio.forum` proposal
+    auditor_candidates = await get_table_auditor_candidates();
 
     // Save JSON
     save(CONTRACT_AUDITOR, "votes", head_block_num, auditor_votes);
+    save(CONTRACT_AUDITOR, "candidates", head_block_num, auditor_candidates);
 }
 
 /**
@@ -108,19 +126,38 @@ async function syncToken(head_block_num: number) {
 }
 
 /**
- * Calculate Tallies
+ * Calculate Forum Tallies
  */
-async function calculateTallies(head_block_num: number) {
-    console.log(`calculateTallies [head_block_num=${head_block_num}]`);
+async function calculateForumTallies(head_block_num: number) {
+    console.log(`calculateForumTallies [head_block_num=${head_block_num}]`);
 
-    const accounts = generateAccounts(forum_votes, delband, voters);
-    const proxies = generateProxies(forum_votes, delband, voters);
-    const tallies = generateTallies(head_block_num, proposals, accounts, proxies, currency_supply);
+    const forum_accounts = generateForumAccounts(forum_votes, delband, voters);
+    const forum_proxies = generateForumProxies(forum_votes, delband, voters);
+    const forum_tallies = generateForumTallies(head_block_num, forum_proposals, forum_accounts, forum_proxies, currency_supply);
 
     // Save JSON
-    save("referendum", "accounts", head_block_num, accounts);
-    save("referendum", "proxies", head_block_num, proxies);
-    save("referendum", "tallies", head_block_num, tallies);
+    save("referendum", "accounts", head_block_num, forum_accounts);
+    save("referendum", "proxies", head_block_num, forum_proxies);
+    save("referendum", "tallies", head_block_num, forum_tallies);
+    save("referendum", "forum.accounts", head_block_num, forum_accounts);
+    save("referendum", "forum.proxies", head_block_num, forum_proxies);
+    save("referendum", "forum.tallies", head_block_num, forum_tallies);
+}
+
+/**
+ * Calculate Auditor Tallies
+ */
+async function calculateAuditorTallies(head_block_num: number) {
+    console.log(`calculateAuditorTallies [head_block_num=${head_block_num}]`);
+
+    const auditor_accounts = generateAuditorAccounts(auditor_votes, delband, voters);
+    const auditor_proxies = generateAuditorProxies(auditor_votes, delband, voters);
+    const auditor_tallies = generateAuditorTallies(head_block_num, auditor_candidates, auditor_accounts, auditor_proxies, currency_supply);
+
+    // Save JSON
+    save("referendum", "auditor.accounts", head_block_num, auditor_accounts);
+    save("referendum", "auditor.proxies", head_block_num, auditor_proxies);
+    save("referendum", "auditor.tallies", head_block_num, auditor_tallies);
 }
 
 /**
@@ -150,14 +187,18 @@ async function save(account: string, table: string, block_num: number, json: any
 
 // Save to AWS S3 bucket
 async function saveS3(account: string, table: string, block_num: number, json: any) {
-    await uploadS3(`${account}/${table}/${block_num}.json`, json);
-    await uploadS3(`${account}/${table}/latest.json`, json);
+    if (!DEBUG) {
+        await uploadS3(`${account}/${table}/${block_num}.json`, json);
+        await uploadS3(`${account}/${table}/latest.json`, json);
+    }
 }
 
 async function quickTasks() {
     const {head_block_num} = await rpc.get_info()
     await syncForum(head_block_num);
-    await calculateTallies(head_block_num);
+    await syncAuditor(head_block_num);
+    await calculateForumTallies(head_block_num);
+    await calculateAuditorTallies(head_block_num);
 }
 
 async function allTasks() {
@@ -166,7 +207,8 @@ async function allTasks() {
     await syncToken(head_block_num);
     await syncForum(head_block_num);
     await syncEosio(head_block_num);
-    await calculateTallies(head_block_num);
+    await calculateForumTallies(head_block_num);
+    await calculateAuditorTallies(head_block_num);
 }
 
 /**

--- a/vote-tally/index.ts
+++ b/vote-tally/index.ts
@@ -56,7 +56,7 @@ async function syncEosio(head_block_num: number) {
     // Calculate EOSIO Stats
     // `eosioVoters` cannot be stored globaly since it will cause memory leaks
     console.log(`calculateEosioStats [head_block_num=${head_block_num}]`);
-    const stats = generateEosioStats(head_block_num, eosioVoters);
+    const stats = generateEosioStats(head_block_num, eosioVoters, currency_supply);
 
     // Save JSON
     await save("eosio", "voters", head_block_num, eosioVoters, false);
@@ -152,7 +152,7 @@ async function calculateAuditorTallies(head_block_num: number) {
 
     const auditor_accounts = generateAuditorAccounts(auditor_votes, delband, voters);
     const auditor_proxies = generateAuditorProxies(auditor_votes, delband, voters);
-    const auditor_tallies = generateAuditorTallies(head_block_num, auditor_candidates, auditor_accounts, auditor_proxies, currency_supply);
+    const auditor_tallies = generateAuditorTallies(head_block_num, auditor_candidates, auditor_accounts, auditor_proxies);
 
     // Save JSON
     save("referendum", "auditor.accounts", head_block_num, auditor_accounts);

--- a/vote-tally/index.ts
+++ b/vote-tally/index.ts
@@ -42,8 +42,9 @@ async function syncEosio(head_block_num: number) {
 
     // fetch `eosio` voters
     let eosioVoters: EosioVoter[] = [];
-    if (DEBUG && fs.existsSync(voters_latest)) eosioVoters = load.sync(voters_latest) // Speed up download of eosio::voters table for debugging
-    else eosioVoters = await get_table_voters();
+    // if (DEBUG && fs.existsSync(voters_latest)) eosioVoters = load.sync(voters_latest) // Speed up download of eosio::voters table for debugging
+    // else
+    eosioVoters = await get_table_voters();
 
     voters = filterVotersByVotes(eosioVoters, forum_votes, auditor_votes);
     voters_owner = new Set(voters.map((row) => row.owner));

--- a/vote-tally/package-lock.json
+++ b/vote-tally/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/cron": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-1.7.0.tgz",
-      "integrity": "sha512-LRu/XiiOExELholyEwEuSTPAEiO+sVR1nXmWEjezneGgYpDyMNVIsjiaHYBoCEUJo4F1hCOlAzQAh80iEUVbKw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-1.7.1.tgz",
+      "integrity": "sha512-48brwgU18DqA0mQX1As5OcJEo1yNjaXMM6Mk4r8K1dOzLJRQ37FE/kCivKx7ClKEHfhX2FdcxKzJ1B744a+V3A==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -30,9 +30,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.13.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.6.tgz",
-      "integrity": "sha512-Xoo/EBzEe8HxTSwaZNLZjaW6M6tA/+GmD3/DZ6uo8qSaolE/9Oarko0oV1fVfrLqOz0tx0nXJB4rdD5c+vixLw==",
+      "version": "11.13.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.14.tgz",
+      "integrity": "sha512-9NjFOB6UUGjJLNANmyIouuaN8YPsPgC4DCOd5lU+DL7HSX/RCfzz0JOtHlspEJq1Ll/JUu/8Cm4wzxpZ8w5sjQ==",
       "dev": true
     },
     "arg": {
@@ -42,9 +42,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.441.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.441.0.tgz",
-      "integrity": "sha512-PnS2lih7p6sPJYUeUSxab7VNsldcHEsCJddHXnnAZRxd2nVa8pAAbPSAauJIN9E6Z4DBhvX3nuQjj+roP/KBTg==",
+      "version": "2.478.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.478.0.tgz",
+      "integrity": "sha512-IN1Rl8PO+dzq00xmPitugC+daQp68jWYgW90kv1OMW5A6saFLpeiGrRiAtoYFmZO7VXrEO5WilLf9PkBkXo+kg==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -79,28 +79,17 @@
       "dev": true
     },
     "cron": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-1.7.0.tgz",
-      "integrity": "sha512-I7S7ES2KZtKPfBTGJ5Brc6X23apE71fgYU/PC5ayh8R6VhECpqvTLe/LTkwAEN3ERFzNKXlWzh/PkwsGg3vkDQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.7.1.tgz",
+      "integrity": "sha512-gmMB/pJcqUVs/NklR1sCGlNYM7TizEw+1gebz20BMc/8bTm/r7QUp3ZPSPlG8Z5XRlvb7qhjEjq/+bdIfUCL2A==",
       "requires": {
         "moment-timezone": "^0.5.x"
       }
     },
     "dapp-client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dapp-client/-/dapp-client-0.3.0.tgz",
-      "integrity": "sha512-f2vb6ztfNAxJ8fgDnlNdZLuWcsaktS7FOTZxQMpiSEWNjdkMl3GpTvkMnRjxn/eN5BwzKn/0mRvnfhDZRivwTw==",
-      "requires": {
-        "debug": "^4.1.1"
-      }
-    },
-    "debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "requires": {
-        "ms": "^2.1.1"
-      }
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/dapp-client/-/dapp-client-0.8.1.tgz",
+      "integrity": "sha512-0GFnq39r8qvMFZIMTlXbM46/TMCnqURUnyWli6rPnQ2J8BzDEYT+OCfZ98QegS3bb9jBFNBP+IPHarTCvMcUgw=="
     },
     "detect-indent": {
       "version": "5.0.0",
@@ -108,9 +97,9 @@
       "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
       "dev": true
     },
     "dotenv": {
@@ -241,11 +230,6 @@
         "moment": ">= 2.9.0"
       }
     },
-    "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -329,13 +313,13 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "ts-node": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.1.0.tgz",
-      "integrity": "sha512-34jpuOrxDuf+O6iW1JpgTRDFynUZ1iEqtYruBqh35gICNjN8x+LpVcPAcwzLPi9VU6mdA3ym+x233nZmZp445A==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
+      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
-        "diff": "^3.1.0",
+        "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
         "yn": "^3.0.0"
@@ -347,9 +331,9 @@
       "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
     },
     "typescript": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.4.tgz",
-      "integrity": "sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
       "dev": true
     },
     "url": {
@@ -372,9 +356,9 @@
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "write-file-atomic": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",

--- a/vote-tally/package.json
+++ b/vote-tally/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "aws-sdk": "^2.441.0",
     "cron": "^1.7.0",
-    "dapp-client": "^0.3.0",
+    "dapp-client": "*",
     "dotenv": "^7.0.0",
     "isomorphic-fetch": "^2.2.1",
     "load-json-file": "^5.3.0",

--- a/vote-tally/src/config.ts
+++ b/vote-tally/src/config.ts
@@ -1,6 +1,6 @@
 // import { JsonRpc } from "eosjs";
 import { DappClient as JsonRpc } from "dapp-client";
-import * as fetch from "isomorphic-fetch";
+const fetch = require("isomorphic-fetch");
 require('dotenv').config()
 
 if (!process.env.NODEOS_ENDPOINT) throw new Error("[NODEOS_ENDPOINT] is required as .env");
@@ -12,6 +12,7 @@ export const CHAIN = process.env.CHAIN;
 
 // Optional
 export const CONTRACT_FORUM = process.env.CONTRACT_FORUM || "eosio.forum";
+export const CONTRACT_AUDITOR = process.env.CONTRACT_AUDITOR || "auditor.bos";
 export const CONTRACT_TOKEN = process.env.CONTRACT_TOKEN || "eosio.token";
 export const TOKEN_SYMBOL = process.env.TOKEN_SYMBOL || "BOS";
 

--- a/vote-tally/src/get_tables.ts
+++ b/vote-tally/src/get_tables.ts
@@ -7,7 +7,8 @@ import { AuditorCandidate } from "./interfaces_auditor";
  * Get Table `eosio::voters`
  */
 export async function get_table_voters() {
-    return (await rpc.get_all_table_rows<EosioVoter>("eosio", "eosio", "voters", "owner")).rows;
+    const result = await rpc.get_all_table_rows<EosioVoter>("eosio", "eosio", "voters", "owner");
+    return result.rows;
 }
 
 /**
@@ -31,7 +32,8 @@ export async function get_table_delband(scopes: Set<string>) {
  * Get Table `eosio.forum::vote`
  */
 export async function get_forum_vote() {
-    return (await rpc.get_all_table_rows<ForumVote>(CONTRACT_FORUM, CONTRACT_FORUM, "vote", "id")).rows;
+    const result = await rpc.get_all_table_rows<ForumVote>(CONTRACT_FORUM, CONTRACT_FORUM, "vote", "id")
+    return result.rows;
 }
 
 /**
@@ -51,7 +53,8 @@ export async function get_auditor_votes() {
  * Get Table `eosio.forum::proposal`
  */
 export async function get_table_forum_proposal() {
-    return (await rpc.get_all_table_rows<ForumProposal>(CONTRACT_FORUM, CONTRACT_FORUM, "proposal", "proposal_name")).rows;
+    const result = await rpc.get_all_table_rows<ForumProposal>(CONTRACT_FORUM, CONTRACT_FORUM, "proposal", "proposal_name");
+    return result.rows;
 }
 
 /**

--- a/vote-tally/src/get_tables.ts
+++ b/vote-tally/src/get_tables.ts
@@ -7,8 +7,7 @@ import { AuditorCandidate } from "./interfaces_auditor";
  * Get Table `eosio::voters`
  */
 export async function get_table_voters() {
-    const result = await rpc.get_all_table_rows<EosioVoter>("eosio", "eosio", "voters", "owner");
-    return result.rows;
+    return get_tables<EosioVoter>("eosio", "eosio", "voters", "owner", ["flags1", "reserved2", "reserved3"]);
 }
 
 /**
@@ -31,43 +30,65 @@ export async function get_table_delband(scopes: Set<string>) {
 /**
  * Get Table `eosio.forum::vote`
  */
-export async function get_forum_vote() {
-    const result = await rpc.get_all_table_rows<ForumVote>(CONTRACT_FORUM, CONTRACT_FORUM, "vote", "id")
-    return result.rows;
+export function get_forum_vote() {
+    return get_tables<ForumVote>(CONTRACT_FORUM, CONTRACT_FORUM, "vote", "id");
 }
 
 /**
  * Get Table `auditor.bos::votes`
  */
-export async function get_auditor_votes() {
-    const result = await rpc.get_all_table_rows<AuditorVote>(CONTRACT_AUDITOR, CONTRACT_AUDITOR, "votes", "voter");
-    return result.rows.map(row => {
-        return {
-            voter: row.voter,
-            candidates: row.candidates
-        }
-    })
+export function get_auditor_votes() {
+    return get_tables<AuditorVote>(CONTRACT_AUDITOR, CONTRACT_AUDITOR, "votes", "voter");
+
 }
 
 /**
  * Get Table `eosio.forum::proposal`
  */
-export async function get_table_forum_proposal() {
-    const result = await rpc.get_all_table_rows<ForumProposal>(CONTRACT_FORUM, CONTRACT_FORUM, "proposal", "proposal_name");
-    return result.rows;
+export function get_table_forum_proposal() {
+    return get_tables<ForumProposal>(CONTRACT_FORUM, CONTRACT_FORUM, "proposal", "proposal_name");
 }
 
 /**
  * Get Table `auditor.bos::candidates`
  */
-export async function get_table_auditor_candidates() {
-    const result = await rpc.get_all_table_rows<AuditorCandidate>(CONTRACT_AUDITOR, CONTRACT_AUDITOR, "candidates", "candidate_name");
-    return result.rows.map(row => {
-        return {
-            candidate_name: row.candidate_name,
-            locked_tokens: row.locked_tokens,
-            is_active: row.is_active,
-            auditor_end_time_stamp: row.auditor_end_time_stamp,
+export function get_table_auditor_candidates() {
+    return get_tables<AuditorCandidate>(CONTRACT_AUDITOR, CONTRACT_AUDITOR, "candidates", "candidate_name", ["total_votes"]);
+}
+
+/**
+ * Get Tables
+ */
+export async function get_tables<T>(code: string, scope: string, table: string, lower_bound_key: string, delete_keys: string[] = []): Promise<T[]> {
+    let lower_bound = "";
+    const limit = 1500;
+    const rows = new Map<string, T>();
+
+    while (true) {
+        console.log(`get_table_rows [${code}::${scope}:${table}] size=${rows.size} lower=${lower_bound}`);
+        const response: any = await rpc.get_table_rows<T>(code, scope, table, {
+            json: true,
+            lower_bound,
+            limit,
+        });
+        for (const row of response.rows) {
+            // Delete extra fields
+            for (const key of delete_keys) {
+                delete row[key];
+            }
+
+            // Adding to Map removes duplicates entries
+            const key = row[lower_bound_key];
+            rows.set(key, row);
+
+            // Set lower bound
+            lower_bound = key;
         }
-    })
+        // prevent hitting rate limits from API endpoints
+        await delay(DELAY_MS);
+
+        // end of table rows
+        if (response.more === false) break;
+    }
+    return Array.from(rows.values());
 }

--- a/vote-tally/src/interfaces.ts
+++ b/vote-tally/src/interfaces.ts
@@ -11,13 +11,20 @@ export interface Voters {
     reserved3: string;
 }
 
-export interface Vote {
+export interface ForumVote {
     id: number;
     proposal_name: string;
     voter: string;
     vote: number;
     vote_json: string;
     updated_at: string;
+}
+
+export interface AuditorVotes {
+    voter: string;
+    proxy: number;
+    weight: number;
+    candidates: string[];
 }
 
 export interface Proposal {
@@ -101,7 +108,7 @@ export interface Stats {
     };
 }
 
-export interface ProxiesVote extends Vote {
+export interface ProxiesVote extends ForumVote {
     staked_proxy: number;
 }
 
@@ -125,7 +132,7 @@ export interface Accounts {
      */
     [account_name: string]: {
         votes: {
-            [proposal_name: string]: Vote;
+            [proposal_name: string]: ForumVote;
         }
         staked: number;
         is_proxy: boolean;
@@ -154,9 +161,9 @@ export interface EosioStats {
      * Total amount of staked BOS used to vote for Block Producers by voters (vote weights by individual voters)
      * > If Proxy has staked BOS, that staked amount will be counted towards `bp_producers_votes `
      */
-    bp_producers_votes;
+    bp_producers_votes: number;
     /**
      * Total amount of proxied staked BOS used to vote for Block Producers (vote weight to proxies)
      */
-    bp_proxy_votes;
+    bp_proxy_votes: number;
 }

--- a/vote-tally/src/interfaces.ts
+++ b/vote-tally/src/interfaces.ts
@@ -54,6 +54,10 @@ export interface EosioStats {
      * Total amount of proxied staked BOS used to vote for Block Producers (vote weight to proxies)
      */
     bp_proxy_votes: number;
+    /**
+     * Currency Supply of `eosio.token`
+     */
+    currency_supply: number;
 }
 
 export interface TallyStats {
@@ -61,10 +65,6 @@ export interface TallyStats {
      * Block Number used for Tally calculations
      */
     block_num: number;
-    /**
-     * Currency Supply used for Tally calculations
-     */
-    currency_supply: number;
     /**
      * Total number of votes per account & proxies
      */

--- a/vote-tally/src/interfaces.ts
+++ b/vote-tally/src/interfaces.ts
@@ -1,4 +1,7 @@
-export interface Voters {
+export * from "./interfaces_forum";
+export * from "./interfaces_auditor";
+
+export interface EosioVoter {
     owner: string;
     proxy: string;
     producers: any[];
@@ -11,59 +14,49 @@ export interface Voters {
     reserved3: string;
 }
 
-export interface ForumVote {
-    id: number;
-    proposal_name: string;
-    voter: string;
-    vote: number;
-    vote_json: string;
-    updated_at: string;
-}
-
-export interface AuditorVotes {
-    voter: string;
-    proxy: number;
-    weight: number;
-    candidates: string[];
-}
-
-export interface Proposal {
-    proposal_name: string;
-    proposer: string;
-    title: string;
-    proposal_json: string;
-    created_at: string;
-    expires_at: string;
-}
-
-export interface Delband {
+export interface EosioDelband {
     from: string;
     to: string;
     net_weight: string;
     cpu_weight: string;
 }
 
-export interface Userres {
+export interface EosioUserres {
     ram_bytes: number;
     cpu_weight: string;
     net_weight: string;
     owner: string;
 }
 
-export interface Tallies {
+export interface EosioTokenCurrencyStats {
+    [symbol: string]: {
+        supply:     string;
+        max_supply: string;
+        issuer:     string;
+    }
+}
+
+export interface EosioStats {
     /**
-     * proposal_name
+     * Block Number used for Summaries calculations
      */
-    [proposal_name: string]: Tally,
+    block_num: number;
+    /**
+     * Total amount of staked BOS used to vote for Block Producers
+     */
+    bp_votes: number;
+    /**
+     * Total amount of staked BOS used to vote for Block Producers by voters (vote weights by individual voters)
+     * > If Proxy has staked BOS, that staked amount will be counted towards `bp_producers_votes `
+     */
+    bp_producers_votes: number;
+    /**
+     * Total amount of proxied staked BOS used to vote for Block Producers (vote weight to proxies)
+     */
+    bp_proxy_votes: number;
 }
 
-export interface Tally {
-    id: string;
-    stats: Stats;
-    proposal: Proposal;
-}
-
-export interface Stats {
+export interface TallyStats {
     /**
      * Block Number used for Tally calculations
      */
@@ -106,64 +99,4 @@ export interface Stats {
         [vote: number]: number
         total: number,
     };
-}
-
-export interface ProxiesVote extends ForumVote {
-    staked_proxy: number;
-}
-
-export interface Proxies {
-    /**
-     * Account Information
-     */
-    [account_name: string]: {
-        votes: {
-            [proposal_name: string]: ProxiesVote;
-        }
-        staked: number;
-        is_proxy: boolean;
-        proxy: string;
-    }
-}
-
-export interface Accounts {
-    /**
-     * Account Information
-     */
-    [account_name: string]: {
-        votes: {
-            [proposal_name: string]: ForumVote;
-        }
-        staked: number;
-        is_proxy: boolean;
-        proxy: string;
-    }
-}
-
-export interface CurrencyStats {
-    [symbol: string]: {
-        supply:     string;
-        max_supply: string;
-        issuer:     string;
-    }
-}
-
-export interface EosioStats {
-    /**
-     * Block Number used for Summaries calculations
-     */
-    block_num: number;
-    /**
-     * Total amount of staked BOS used to vote for Block Producers
-     */
-    bp_votes: number;
-    /**
-     * Total amount of staked BOS used to vote for Block Producers by voters (vote weights by individual voters)
-     * > If Proxy has staked BOS, that staked amount will be counted towards `bp_producers_votes `
-     */
-    bp_producers_votes: number;
-    /**
-     * Total amount of proxied staked BOS used to vote for Block Producers (vote weight to proxies)
-     */
-    bp_proxy_votes: number;
 }

--- a/vote-tally/src/interfaces_auditor.ts
+++ b/vote-tally/src/interfaces_auditor.ts
@@ -1,0 +1,64 @@
+import { TallyStats } from "./interfaces";
+
+export interface AuditorCandidate {
+    candidate_name: string;
+    locked_tokens: string;
+    // total_votes: number;
+    is_active: boolean;
+    auditor_end_time_stamp: string;
+}
+
+export interface AuditorVote {
+    voter: string;
+    candidates: string[];
+}
+
+export interface AuditorProxiesVote extends AuditorVote {
+    staked_proxy: number;
+}
+
+
+export interface AuditorTallies {
+    /**
+     * candidate_name
+     */
+    [candidate_name: string]: AuditorTally,
+}
+
+export interface AuditorTally {
+    id: string;
+    stats: TallyStats;
+    candidate: AuditorCandidate;
+}
+
+export interface AuditorProxiesVote extends AuditorVote {
+    staked_proxy: number;
+}
+
+export interface AuditorProxies {
+    /**
+     * Account Information
+     */
+    [account_name: string]: {
+        votes: {
+            [candidate_name: string]: AuditorProxiesVote
+        }
+        staked: number;
+        is_proxy: boolean;
+        proxy: string;
+    }
+}
+
+export interface AuditorAccounts {
+    /**
+     * Account Information
+     */
+    [account_name: string]: {
+        votes: {
+            [candidate_name: string]: AuditorVote
+        }
+        staked: number;
+        is_proxy: boolean;
+        proxy: string;
+    }
+}

--- a/vote-tally/src/interfaces_forum.ts
+++ b/vote-tally/src/interfaces_forum.ts
@@ -1,0 +1,64 @@
+import { TallyStats } from "./interfaces";
+
+export interface ForumVote {
+    id: number;
+    proposal_name: string;
+    voter: string;
+    vote: number;
+    vote_json: string;
+    updated_at: string;
+}
+
+export interface ForumProxiesVote extends ForumVote {
+    staked_proxy: number;
+}
+
+export interface ForumProposal {
+    proposal_name: string;
+    proposer: string;
+    title: string;
+    proposal_json: string;
+    created_at: string;
+    expires_at: string;
+}
+
+export interface ForumTallies {
+    /**
+     * proposal_name
+     */
+    [proposal_name: string]: ForumTally,
+}
+
+export interface ForumTally {
+    id: string;
+    stats: TallyStats;
+    proposal: ForumProposal;
+}
+
+export interface ForumProxies {
+    /**
+     * Account Information
+     */
+    [account_name: string]: {
+        votes: {
+            [proposal_name: string]: ForumProxiesVote;
+        }
+        staked: number;
+        is_proxy: boolean;
+        proxy: string;
+    }
+}
+
+export interface ForumAccounts {
+    /**
+     * Account Information
+     */
+    [account_name: string]: {
+        votes: {
+            [proposal_name: string]: ForumVote;
+        }
+        staked: number;
+        is_proxy: boolean;
+        proxy: string;
+    }
+}

--- a/vote-tally/src/stats.ts
+++ b/vote-tally/src/stats.ts
@@ -1,6 +1,6 @@
 import { EosioVoter, EosioStats } from "./interfaces";
 
-export function generateEosioStats(head_block_num: number, voters: EosioVoter[]): EosioStats {
+export function generateEosioStats(head_block_num: number, voters: EosioVoter[], currency_supply: number): EosioStats {
     let bp_votes = 0;
     let bp_producers_votes = 0;
     let bp_proxy_votes = 0;
@@ -26,6 +26,7 @@ export function generateEosioStats(head_block_num: number, voters: EosioVoter[])
         block_num: head_block_num,
         bp_votes,
         bp_producers_votes,
-        bp_proxy_votes
+        bp_proxy_votes,
+        currency_supply,
     }
 }

--- a/vote-tally/src/stats.ts
+++ b/vote-tally/src/stats.ts
@@ -1,6 +1,6 @@
-import { Voters, EosioStats } from "./interfaces";
+import { EosioVoter, EosioStats } from "./interfaces";
 
-export function generateEosioStats(head_block_num: number, voters: Voters[]): EosioStats {
+export function generateEosioStats(head_block_num: number, voters: EosioVoter[]): EosioStats {
     let bp_votes = 0;
     let bp_producers_votes = 0;
     let bp_proxy_votes = 0;

--- a/vote-tally/src/tallies.ts
+++ b/vote-tally/src/tallies.ts
@@ -1,5 +1,5 @@
 import { parseTokenString } from "./utils";
-import { Voters, Delband, Accounts, Vote, Proxies, Proposal, Tallies, Tally, Stats } from "./interfaces";
+import { Voters, Delband, Accounts, ForumVote, Proxies, Proposal, Tallies, Tally, Stats } from "./interfaces";
 
 function defaultAccount() {
     return {
@@ -44,7 +44,7 @@ export function countStaked(delband: Delband) {
     return cpu + net;
 }
 
-export function filterVotersByVotes(voters: Voters[], votes: Vote[]) {
+export function filterVotersByVotes(voters: Voters[], votes: ForumVote[]) {
     const results: Voters[] = [];
     const voted = new Set();
 
@@ -62,7 +62,7 @@ export function filterVotersByVotes(voters: Voters[], votes: Vote[]) {
     return results;
 }
 
-export function generateProxies(votes: Vote[], delband: Delband[], voters: Voters[]): Proxies {
+export function generateProxies(votes: ForumVote[], delband: Delband[], voters: Voters[]): Proxies {
     const accounts = generateAccounts(votes, delband, voters, false);
     const accountsProxies: any = generateAccounts(votes, delband, voters, true);
 
@@ -92,7 +92,7 @@ export function generateProxies(votes: Vote[], delband: Delband[], voters: Voter
     return accountsProxies;
 }
 
-export function generateAccounts(votes: Vote[], delband: Delband[], voters: Voters[], proxies = false): Accounts {
+export function generateAccounts(votes: ForumVote[], delband: Delband[], voters: Voters[], proxies = false): Accounts {
     const accounts: Accounts = {};
     const voted = new Set(); // track who has voted
 

--- a/vote-tally/src/tallies.ts
+++ b/vote-tally/src/tallies.ts
@@ -1,7 +1,9 @@
 import { parseTokenString } from "./utils";
-import { Voters, Delband, Accounts, ForumVote, Proxies, Proposal, Tallies, Tally, Stats } from "./interfaces";
+import { TallyStats, EosioDelband, EosioVoter } from "./interfaces";
+import { ForumVote } from "./interfaces_forum";
+import { AuditorVote } from "./interfaces_auditor";
 
-function defaultAccount() {
+export function defaultAccount() {
     return {
         votes: {},
         staked: 0,
@@ -10,7 +12,7 @@ function defaultAccount() {
     };
 }
 
-export function defaultStats(block_num: number, currency_supply: number): Stats {
+export function defaultStats(block_num: number, currency_supply: number): TallyStats {
     return {
         votes: {
             total: 0,
@@ -37,19 +39,23 @@ export function defaultStats(block_num: number, currency_supply: number): Stats 
     };
 }
 
-export function countStaked(delband: Delband) {
+export function countStaked(delband: EosioDelband) {
     if (!delband) return 0;
     const cpu = parseTokenString(delband.cpu_weight).amount;
     const net = parseTokenString(delband.net_weight).amount;
     return cpu + net;
 }
 
-export function filterVotersByVotes(voters: Voters[], votes: ForumVote[]) {
-    const results: Voters[] = [];
+export function filterVotersByVotes(voters: EosioVoter[], forum_votes: ForumVote[], auditor_votes: AuditorVote[]) {
+    const results: EosioVoter[] = [];
     const voted = new Set();
 
     // Only track accounts who has casted votes
-    for (const row of votes) {
+    for (const row of forum_votes) {
+        voted.add(row.voter);
+    }
+
+    for (const row of auditor_votes) {
         voted.add(row.voter);
     }
 
@@ -60,187 +66,4 @@ export function filterVotersByVotes(voters: Voters[], votes: ForumVote[]) {
         if (voted.has(owner) || voted.has(row.proxy)) results.push(row);
     }
     return results;
-}
-
-export function generateProxies(votes: ForumVote[], delband: Delband[], voters: Voters[]): Proxies {
-    const accounts = generateAccounts(votes, delband, voters, false);
-    const accountsProxies: any = generateAccounts(votes, delband, voters, true);
-
-    for (const proxyName of Object.keys(accountsProxies)) {
-        const proxy = accountsProxies[proxyName];
-
-        for (const proposalName of Object.keys(proxy.votes)) {
-            // Initialize `proxy_staked` for each proposal using self delegated EOS from proxy
-            proxy.votes[proposalName].staked_proxy = Number(proxy.staked);
-
-            for (const accountName of Object.keys(accounts)) {
-                const account = accounts[accountName];
-
-                // Check if account belongs to proxy
-                if (account.proxy !== proxyName) continue;
-
-                // Check if user has already voted for proposal
-                // Do not add user `stake` if already voted for same proposal
-                if (account.votes[proposalName]) continue;
-
-                // Add user `staked` to `staked_proxy`
-                accountsProxies[proxyName].votes[proposalName].staked_proxy += Number(account.staked);
-            }
-        }
-    }
-
-    return accountsProxies;
-}
-
-export function generateAccounts(votes: ForumVote[], delband: Delband[], voters: Voters[], proxies = false): Accounts {
-    const accounts: Accounts = {};
-    const voted = new Set(); // track who has voted
-
-    // Only track accounts who has casted votes
-    for (const row of votes) {
-        if (!accounts[row.voter]) accounts[row.voter] = defaultAccount();
-
-        const account = accounts[row.voter];
-        if (account.votes) account.votes[row.proposal_name] = row;
-        voted.add(row.voter);
-    }
-
-    // Load Voter Information
-    for (const row of voters) {
-        const owner = row.owner;
-
-        // Voter is only included if voted or proxied to a proxy who has voted
-        if (voted.has(owner) || voted.has(row.proxy)) {
-            if (!accounts[owner]) accounts[owner] = defaultAccount();
-            accounts[owner].staked = row.staked;
-            accounts[owner].is_proxy = Boolean(row.is_proxy);
-            accounts[owner].proxy = row.proxy;
-        }
-    }
-
-    // Load Self Delegated Bandwidth
-    for (const row of delband) {
-        const owner = row.from;
-        if (!accounts[owner]) accounts[owner] = defaultAccount();
-        if (!accounts[owner].staked) accounts[owner].staked = countStaked(row);
-    }
-
-    // Remove/Include proxies
-    for (const owner of Object.keys(accounts)) {
-        const account = accounts[owner];
-
-        // Proxies
-        if (proxies !== account.is_proxy) delete accounts[owner];
-    }
-
-    return accounts;
-}
-
-export function generateTallies(block_num: number, proposals: Proposal[], accounts: Accounts, proxies: Accounts, currency_supply: number): Tallies {
-    const tallies: Tallies = {};
-
-    for (const proposal of proposals) {
-        tallies[proposal.proposal_name] = generateTally(block_num, proposal, accounts, proxies, currency_supply);
-    }
-    return tallies;
-}
-
-export function generateTally(block_num: number, proposal: Proposal, accounts: Accounts, proxies: Accounts, currency_supply: number): Tally {
-    const { proposal_name } = proposal;
-    const stats = defaultStats(block_num, currency_supply);
-
-    // Calculate account's staked
-    for (const owner of Object.keys(accounts)) {
-        const account = accounts[owner];
-        const { votes } = account;
-        const staked = Number(account.staked);
-
-        if (votes[proposal_name]) {
-            const { vote } = votes[proposal_name];
-            // Set to 0 if undefined
-            if (!stats.accounts[vote]) stats.accounts[vote] = 0;
-            if (!stats.staked[vote]) stats.staked[vote] = 0;
-            if (!stats.votes[vote]) stats.votes[vote] = 0;
-
-            // Add voting weights
-            stats.accounts[vote] += staked;
-            stats.accounts.total += staked;
-            stats.staked[vote] += staked;
-            stats.staked.total += staked;
-
-            // Voting Count
-            stats.votes[vote] += 1;
-            stats.votes.total += 1;
-            stats.votes.accounts += 1;
-        }
-    }
-    // Calculate proxies's staked
-    // TO-DO: Create a method to support both accounts & proxies staked portion (removes 15 lines of code)
-    for (const owner of Object.keys(proxies)) {
-        const account = proxies[owner];
-        const { votes } = account;
-        const staked = Number(account.staked);
-
-        if (votes[proposal_name]) {
-            const { vote } = votes[proposal_name];
-            // Set to 0 if undefined
-            if (!stats.proxies[vote]) stats.proxies[vote] = 0;
-            if (!stats.staked[vote]) stats.staked[vote] = 0;
-            if (!stats.votes[vote]) stats.votes[vote] = 0;
-
-            // Add voting weights
-            stats.proxies[vote] += staked;
-            stats.proxies.total += staked;
-            stats.staked[vote] += staked;
-            stats.staked.total += staked;
-
-            // Voting Count
-            stats.votes[vote] += 1;
-            stats.votes.total += 1;
-            stats.votes.proxies += 1;
-        }
-    }
-
-    // Additional proxied staked weights via account's staked who have no voted
-    for (const proxy of Object.keys(proxies)) {
-        const proxyAccount = proxies[proxy];
-        // Skip proxy, did not vote for proposal
-        if (!proxyAccount.votes[proposal_name]) continue;
-
-        const { vote } = proxyAccount.votes[proposal_name];
-        let staked = 0;
-
-        for (const owner of Object.keys(accounts)) {
-            const account = accounts[owner];
-
-            // Skip user isn't using this proxy
-            if (account.proxy !== proxy) continue;
-
-            // Skip user has already voted
-            if (account.votes[proposal_name]) continue;
-
-            // Add user's stake to proxies
-            staked += Number(account.staked);
-        }
-
-        // Set to 0 if undefined
-        if (!stats.proxies[vote]) stats.proxies[vote] = 0;
-        if (!stats.staked[vote]) stats.staked[vote] = 0;
-
-        stats.proxies[vote] += staked;
-        stats.proxies.total += staked;
-        stats.staked[vote] += staked;
-        stats.staked.total += staked;
-    }
-
-    // Proposal unique ID
-    // ProposalName_YYYYMMDD // awesomeprop_20181206
-    const date = proposal.created_at.split("T")[0].replace(/-/g, "");
-    const id = `${proposal_name}_${date}`;
-
-    return {
-        id,
-        proposal,
-        stats,
-    };
 }

--- a/vote-tally/src/tallies.ts
+++ b/vote-tally/src/tallies.ts
@@ -12,7 +12,7 @@ export function defaultAccount() {
     };
 }
 
-export function defaultStats(block_num: number, currency_supply: number): TallyStats {
+export function defaultStats(block_num: number): TallyStats {
     return {
         votes: {
             total: 0,
@@ -35,7 +35,6 @@ export function defaultStats(block_num: number, currency_supply: number): TallyS
             total: 0,
         },
         block_num,
-        currency_supply,
     };
 }
 

--- a/vote-tally/src/tallies_auditor.ts
+++ b/vote-tally/src/tallies_auditor.ts
@@ -1,0 +1,189 @@
+import { EosioVoter, EosioDelband, AuditorAccounts, AuditorVote, AuditorProxies, AuditorTallies, AuditorTally, TallyStats } from "./interfaces";
+import { AuditorCandidate } from "./interfaces_auditor";
+import { countStaked, defaultStats, defaultAccount } from "./tallies";
+
+export function generateAuditorProxies(votes: AuditorVote[], delband: EosioDelband[], voters: EosioVoter[]): AuditorProxies {
+    const accounts = generateAuditorAccounts(votes, delband, voters, false);
+    const accountsProxies: any = generateAuditorAccounts(votes, delband, voters, true);
+
+    for (const proxyName of Object.keys(accountsProxies)) {
+        const proxy = accountsProxies[proxyName];
+
+        for (const candidate_name of Object.keys(proxy.votes)) {
+            // Initialize `proxy_staked` for each proposal using self delegated EOS from proxy
+            proxy.votes[candidate_name].staked_proxy = Number(proxy.staked);
+
+            for (const accountName of Object.keys(accounts)) {
+                const account = accounts[accountName];
+
+                // Check if account belongs to proxy
+                if (account.proxy !== proxyName) continue;
+
+                // Check if user has already voted for proposal
+                // Do not add user `stake` if already voted for same proposal
+                if (account.votes[candidate_name]) continue;
+
+                // Add user `staked` to `staked_proxy`
+                accountsProxies[proxyName].votes[candidate_name].staked_proxy += Number(account.staked);
+            }
+        }
+    }
+
+    return accountsProxies;
+}
+
+export function generateAuditorAccounts(votes: AuditorVote[], delband: EosioDelband[], voters: EosioVoter[], proxies = false): AuditorAccounts {
+    const accounts: AuditorAccounts = {};
+    const voted = new Set(); // track who has voted
+
+    // Only track accounts who has casted votes
+    for (const row of votes) {
+        if (!accounts[row.voter]) accounts[row.voter] = defaultAccount();
+
+        const account = accounts[row.voter];
+
+        for (const candidate_name of row.candidates) {
+            account.votes[candidate_name] = row;
+            voted.add(row.voter);
+        }
+    }
+
+    // Load Voter Information
+    for (const row of voters) {
+        const owner = row.owner;
+
+        // Voter is only included if voted or proxied to a proxy who has voted
+        if (voted.has(owner) || voted.has(row.proxy)) {
+            if (!accounts[owner]) accounts[owner] = defaultAccount();
+            accounts[owner].staked = row.staked;
+            accounts[owner].is_proxy = Boolean(row.is_proxy);
+            accounts[owner].proxy = row.proxy;
+        }
+    }
+
+    // Load Self Delegated Bandwidth
+    for (const row of delband) {
+        const owner = row.from;
+        if (!accounts[owner]) accounts[owner] = defaultAccount();
+        if (!accounts[owner].staked) accounts[owner].staked = countStaked(row);
+    }
+
+    // Remove/Include proxies
+    for (const owner of Object.keys(accounts)) {
+        const account = accounts[owner];
+
+        // Proxies
+        if (proxies !== account.is_proxy) delete accounts[owner];
+    }
+
+    return accounts;
+}
+
+export function generateAuditorTallies(block_num: number, candidates: AuditorCandidate[], accounts: AuditorAccounts, proxies: AuditorAccounts, currency_supply: number): AuditorTallies {
+    const tallies: AuditorTallies = {};
+
+    for (const candidate of candidates) {
+        tallies[candidate.candidate_name] = generateAuditorTally(block_num, candidate, accounts, proxies, currency_supply);
+    }
+    return tallies;
+}
+
+export function generateAuditorTally(block_num: number, candidate: AuditorCandidate, accounts: AuditorAccounts, proxies: AuditorAccounts, currency_supply: number): AuditorTally {
+    const { candidate_name } = candidate;
+    const stats = defaultStats(block_num, currency_supply);
+
+    // Calculate account's staked
+    for (const owner of Object.keys(accounts)) {
+        const account = accounts[owner];
+        const { votes } = account;
+        const staked = Number(account.staked);
+
+        if (votes[candidate_name]) {
+            // Default vote to 1 = yes
+            const vote = 1;
+
+            // Set to 0 if undefined
+            if (!stats.accounts[vote]) stats.accounts[vote] = 0;
+            if (!stats.staked[vote]) stats.staked[vote] = 0;
+            if (!stats.votes[vote]) stats.votes[vote] = 0;
+
+            // Add voting weights
+            stats.accounts[vote] += staked;
+            stats.accounts.total += staked;
+            stats.staked[vote] += staked;
+            stats.staked.total += staked;
+
+            // Voting Count
+            stats.votes[vote] += 1;
+            stats.votes.total += 1;
+            stats.votes.accounts += 1;
+        }
+    }
+    // Calculate proxies's staked
+    // TO-DO: Create a method to support both accounts & proxies staked portion (removes 15 lines of code)
+    for (const owner of Object.keys(proxies)) {
+        const account = proxies[owner];
+        const { votes } = account;
+        const staked = Number(account.staked);
+
+        if (votes[candidate_name]) {
+            // Default vote to 1 = yes
+            const vote = 1;
+
+            // Set to 0 if undefined
+            if (!stats.proxies[vote]) stats.proxies[vote] = 0;
+            if (!stats.staked[vote]) stats.staked[vote] = 0;
+            if (!stats.votes[vote]) stats.votes[vote] = 0;
+
+            // Add voting weights
+            stats.proxies[vote] += staked;
+            stats.proxies.total += staked;
+            stats.staked[vote] += staked;
+            stats.staked.total += staked;
+
+            // Voting Count
+            stats.votes[vote] += 1;
+            stats.votes.total += 1;
+            stats.votes.proxies += 1;
+        }
+    }
+
+    // Additional proxied staked weights via account's staked who have no voted
+    for (const proxy of Object.keys(proxies)) {
+        const proxyAccount = proxies[proxy];
+        // Skip proxy, did not vote for proposal
+        if (!proxyAccount.votes[candidate_name]) continue;
+
+        // Default vote to 1 = yes
+        const vote = 1;
+        let staked = 0;
+
+        for (const owner of Object.keys(accounts)) {
+            const account = accounts[owner];
+
+            // Skip user isn't using this proxy
+            if (account.proxy !== proxy) continue;
+
+            // Skip user has already voted
+            if (account.votes[candidate_name]) continue;
+
+            // Add user's stake to proxies
+            staked += Number(account.staked);
+        }
+
+        // Set to 0 if undefined
+        if (!stats.proxies[vote]) stats.proxies[vote] = 0;
+        if (!stats.staked[vote]) stats.staked[vote] = 0;
+
+        stats.proxies[vote] += staked;
+        stats.proxies.total += staked;
+        stats.staked[vote] += staked;
+        stats.staked.total += staked;
+    }
+
+    return {
+        id: candidate_name,
+        candidate,
+        stats,
+    };
+}

--- a/vote-tally/src/tallies_auditor.ts
+++ b/vote-tally/src/tallies_auditor.ts
@@ -79,18 +79,18 @@ export function generateAuditorAccounts(votes: AuditorVote[], delband: EosioDelb
     return accounts;
 }
 
-export function generateAuditorTallies(block_num: number, candidates: AuditorCandidate[], accounts: AuditorAccounts, proxies: AuditorAccounts, currency_supply: number): AuditorTallies {
+export function generateAuditorTallies(block_num: number, candidates: AuditorCandidate[], accounts: AuditorAccounts, proxies: AuditorAccounts): AuditorTallies {
     const tallies: AuditorTallies = {};
 
     for (const candidate of candidates) {
-        tallies[candidate.candidate_name] = generateAuditorTally(block_num, candidate, accounts, proxies, currency_supply);
+        tallies[candidate.candidate_name] = generateAuditorTally(block_num, candidate, accounts, proxies);
     }
     return tallies;
 }
 
-export function generateAuditorTally(block_num: number, candidate: AuditorCandidate, accounts: AuditorAccounts, proxies: AuditorAccounts, currency_supply: number): AuditorTally {
+export function generateAuditorTally(block_num: number, candidate: AuditorCandidate, accounts: AuditorAccounts, proxies: AuditorAccounts): AuditorTally {
     const { candidate_name } = candidate;
-    const stats = defaultStats(block_num, currency_supply);
+    const stats = defaultStats(block_num);
 
     // Calculate account's staked
     for (const owner of Object.keys(accounts)) {

--- a/vote-tally/src/tallies_forum.ts
+++ b/vote-tally/src/tallies_forum.ts
@@ -1,0 +1,185 @@
+import { EosioVoter, EosioDelband, ForumAccounts, ForumVote, ForumProxies, ForumProposal, ForumTallies, ForumTally } from "./interfaces";
+import { defaultAccount, countStaked, defaultStats } from "./tallies";
+
+export function generateForumProxies(votes: ForumVote[], delband: EosioDelband[], voters: EosioVoter[]): ForumProxies {
+    const accounts = generateForumAccounts(votes, delband, voters, false);
+    const accountsProxies: any = generateForumAccounts(votes, delband, voters, true);
+
+    for (const proxyName of Object.keys(accountsProxies)) {
+        const proxy = accountsProxies[proxyName];
+
+        for (const proposalName of Object.keys(proxy.votes)) {
+            // Initialize `proxy_staked` for each proposal using self delegated EOS from proxy
+            proxy.votes[proposalName].staked_proxy = Number(proxy.staked);
+
+            for (const accountName of Object.keys(accounts)) {
+                const account = accounts[accountName];
+
+                // Check if account belongs to proxy
+                if (account.proxy !== proxyName) continue;
+
+                // Check if user has already voted for proposal
+                // Do not add user `stake` if already voted for same proposal
+                if (account.votes[proposalName]) continue;
+
+                // Add user `staked` to `staked_proxy`
+                accountsProxies[proxyName].votes[proposalName].staked_proxy += Number(account.staked);
+            }
+        }
+    }
+
+    return accountsProxies;
+}
+
+export function generateForumAccounts(votes: ForumVote[], delband: EosioDelband[], voters: EosioVoter[], proxies = false): ForumAccounts {
+    const accounts: ForumAccounts = {};
+    const voted = new Set(); // track who has voted
+
+    // Only track accounts who has casted votes
+    for (const row of votes) {
+        if (!accounts[row.voter]) accounts[row.voter] = defaultAccount();
+
+        const account = accounts[row.voter];
+        if (account.votes) account.votes[row.proposal_name] = row;
+        voted.add(row.voter);
+    }
+
+    // Load Voter Information
+    for (const row of voters) {
+        const owner = row.owner;
+
+        // Voter is only included if voted or proxied to a proxy who has voted
+        if (voted.has(owner) || voted.has(row.proxy)) {
+            if (!accounts[owner]) accounts[owner] = defaultAccount();
+            accounts[owner].staked = row.staked;
+            accounts[owner].is_proxy = Boolean(row.is_proxy);
+            accounts[owner].proxy = row.proxy;
+        }
+    }
+
+    // Load Self Delegated Bandwidth
+    for (const row of delband) {
+        const owner = row.from;
+        if (!accounts[owner]) accounts[owner] = defaultAccount();
+        if (!accounts[owner].staked) accounts[owner].staked = countStaked(row);
+    }
+
+    // Remove/Include proxies
+    for (const owner of Object.keys(accounts)) {
+        const account = accounts[owner];
+
+        // Proxies
+        if (proxies !== account.is_proxy) delete accounts[owner];
+    }
+
+    return accounts;
+}
+
+export function generateForumTallies(block_num: number, proposals: ForumProposal[], accounts: ForumAccounts, proxies: ForumAccounts, currency_supply: number): ForumTallies {
+    const tallies: ForumTallies = {};
+
+    for (const proposal of proposals) {
+        tallies[proposal.proposal_name] = generateForumTally(block_num, proposal, accounts, proxies, currency_supply);
+    }
+    return tallies;
+}
+
+export function generateForumTally(block_num: number, proposal: ForumProposal, accounts: ForumAccounts, proxies: ForumAccounts, currency_supply: number): ForumTally {
+    const { proposal_name } = proposal;
+    const stats = defaultStats(block_num, currency_supply);
+
+    // Calculate account's staked
+    for (const owner of Object.keys(accounts)) {
+        const account = accounts[owner];
+        const { votes } = account;
+        const staked = Number(account.staked);
+
+        if (votes[proposal_name]) {
+            const { vote } = votes[proposal_name];
+            // Set to 0 if undefined
+            if (!stats.accounts[vote]) stats.accounts[vote] = 0;
+            if (!stats.staked[vote]) stats.staked[vote] = 0;
+            if (!stats.votes[vote]) stats.votes[vote] = 0;
+
+            // Add voting weights
+            stats.accounts[vote] += staked;
+            stats.accounts.total += staked;
+            stats.staked[vote] += staked;
+            stats.staked.total += staked;
+
+            // Voting Count
+            stats.votes[vote] += 1;
+            stats.votes.total += 1;
+            stats.votes.accounts += 1;
+        }
+    }
+    // Calculate proxies's staked
+    // TO-DO: Create a method to support both accounts & proxies staked portion (removes 15 lines of code)
+    for (const owner of Object.keys(proxies)) {
+        const account = proxies[owner];
+        const { votes } = account;
+        const staked = Number(account.staked);
+
+        if (votes[proposal_name]) {
+            const { vote } = votes[proposal_name];
+            // Set to 0 if undefined
+            if (!stats.proxies[vote]) stats.proxies[vote] = 0;
+            if (!stats.staked[vote]) stats.staked[vote] = 0;
+            if (!stats.votes[vote]) stats.votes[vote] = 0;
+
+            // Add voting weights
+            stats.proxies[vote] += staked;
+            stats.proxies.total += staked;
+            stats.staked[vote] += staked;
+            stats.staked.total += staked;
+
+            // Voting Count
+            stats.votes[vote] += 1;
+            stats.votes.total += 1;
+            stats.votes.proxies += 1;
+        }
+    }
+
+    // Additional proxied staked weights via account's staked who have no voted
+    for (const proxy of Object.keys(proxies)) {
+        const proxyAccount = proxies[proxy];
+        // Skip proxy, did not vote for proposal
+        if (!proxyAccount.votes[proposal_name]) continue;
+
+        const { vote } = proxyAccount.votes[proposal_name];
+        let staked = 0;
+
+        for (const owner of Object.keys(accounts)) {
+            const account = accounts[owner];
+
+            // Skip user isn't using this proxy
+            if (account.proxy !== proxy) continue;
+
+            // Skip user has already voted
+            if (account.votes[proposal_name]) continue;
+
+            // Add user's stake to proxies
+            staked += Number(account.staked);
+        }
+
+        // Set to 0 if undefined
+        if (!stats.proxies[vote]) stats.proxies[vote] = 0;
+        if (!stats.staked[vote]) stats.staked[vote] = 0;
+
+        stats.proxies[vote] += staked;
+        stats.proxies.total += staked;
+        stats.staked[vote] += staked;
+        stats.staked.total += staked;
+    }
+
+    // Proposal unique ID
+    // ProposalName_YYYYMMDD // awesomeprop_20181206
+    const date = proposal.created_at.split("T")[0].replace(/-/g, "");
+    const id = `${proposal_name}_${date}`;
+
+    return {
+        id,
+        proposal,
+        stats,
+    };
+}

--- a/vote-tally/src/tallies_forum.ts
+++ b/vote-tally/src/tallies_forum.ts
@@ -86,7 +86,7 @@ export function generateForumTallies(block_num: number, proposals: ForumProposal
 
 export function generateForumTally(block_num: number, proposal: ForumProposal, accounts: ForumAccounts, proxies: ForumAccounts, currency_supply: number): ForumTally {
     const { proposal_name } = proposal;
-    const stats = defaultStats(block_num, currency_supply);
+    const stats = defaultStats(block_num);
 
     // Calculate account's staked
     for (const owner of Object.keys(accounts)) {

--- a/vote-tally/tsconfig.json
+++ b/vote-tally/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+
+    /* Module Resolution Options */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+  }
+}


### PR DESCRIPTION
### Modifications

- S3 Bucket filepath change from `referendum::tallies` to =>
  -`referendum::forum.tallies`
  -`referendum::auditor.tallies`
- Added `currency_supply` to `eosio/stats`
- Removed `currency_supply` from Tally Statistics

### New S3 Buckets

`referendum::auditor.tallies` (tallies for `auditor.bos` voters)

- https://s3.amazonaws.com/bos.referendum/referendum/auditor.tallies/latest.json

`referendum::auditor.accounts` (account details for `auditor.bos` voters)

- https://s3.amazonaws.com/bos.referendum/referendum/auditor.accounts/latest.json

`referendum::auditor.proxies` (proxies details for `auditor.bos` voters)

- https://s3.amazonaws.com/bos.referendum/referendum/auditor.proxies/latest.json

### Example of Auditor Tally

Very similar to `eosio.forum` tally

```json
{
	"appleofmyeye": {
		"id": "appleofmyeye",
		"candidate": {
			"candidate_name": "appleofmyeye",
			"locked_tokens": "100.0000 BOS",
			"is_active": 1,
			"auditor_end_time_stamp": "1970-01-01T00:00:00"
		},
		"stats": {
			"votes": {
				"1": 1,
				"total": 1,
				"proxies": 1,
				"accounts": 0
			},
			"accounts": {
				"0": 0,
				"1": 0,
				"total": 0
			},
			"proxies": {
				"0": 0,
				"1": 4800000202,
				"total": 4800000202
			},
			"staked": {
				"0": 0,
				"1": 4800000202,
				"total": 4800000202
			},
			"block_num": 26798022,
			"currency_supply": 1008825790.3709
		}
	},
```