### PR TITLE
Allow multiple escrows to be created by sender

### DIFF
--- a/contracts/escrow.bos/README.md
+++ b/contracts/escrow.bos/README.md
@@ -20,7 +20,7 @@ $ bosc tx create escrow.bos init '{"sender":"bet.bos","receiver":"<RECEIVER>","a
 > BOS funds must be `transfer` into the `escrow.bos` account before starting another escrow
 
 ```bash
-$ bosc transfer bet.bos escrow.bos "100.0000 BOS" -m "Fund BOS escrow" -p bet.bos
+$ bosc transfer bet.bos escrow.bos "100.0000 BOS" -m "<ESCROW NAME>" -p bet.bos
 ```
 
 ### Approve Escrow

--- a/contracts/escrow.bos/include/escrow.hpp
+++ b/contracts/escrow.bos/include/escrow.hpp
@@ -28,7 +28,7 @@ class [[eosio::contract("escrow")]] escrow : public eosio::contract {
 
         escrow(name s, name code, datastream<const char *> ds)
                 : contract(s, code, ds),
-                  escrows(_self, _self.value) {
+                  escrows( get_self(), get_self().value) {
             sending_code = name{code};
         }
 

--- a/contracts/escrow.bos/include/escrow.hpp
+++ b/contracts/escrow.bos/include/escrow.hpp
@@ -6,22 +6,8 @@
 #include <string>
 #include <optional>
 
-using eosio::const_mem_fun;
-using eosio::indexed_by;
-using eosio::multi_index;
-using eosio::extended_asset;
-using eosio::check;
-using eosio::datastream;
-using eosio::contract;
-using eosio::print;
-using eosio::name;
-using eosio::asset;
-using eosio::symbol;
-using eosio::time_point_sec;
-using eosio::current_time_point;
-using std::vector;
-using std::function;
-using std::string;
+using namespace eosio;
+using namespace std;
 
 class [[eosio::contract("escrow")]] escrow : public eosio::contract {
     public:

--- a/contracts/escrow.bos/src/escrow.cpp
+++ b/contracts/escrow.bos/src/escrow.cpp
@@ -55,11 +55,6 @@ void escrow::init( const name           sender,
     time_point_sec max_expires_at = current_time_point() + time_point_sec(SIX_MONTHS_IN_SECONDS);
     check( expires_at <= max_expires_at, "[expires_at] must be within 6 months from now.");
 
-    // Enforce `sender` as BOS Executive & `approver` as EOSIO
-    // Asserts should be removed once escrow.bos is ready for public use
-    check( sender == name("bet.bos"), "[sender] must be bet.bos");
-    check( approver == name("eosio"), "[approver] must be eosio");
-
     // Notify the following accounts
     require_recipient( sender );
     require_recipient( receiver );

--- a/contracts/escrow.bos/src/escrow.cpp
+++ b/contracts/escrow.bos/src/escrow.cpp
@@ -27,8 +27,7 @@ void escrow::transfer( const name     from,
     check( sender == from, "[from] does not match `sender` using this `escrow_name`" );
 
     // escrow must be empty
-    check( quantity.amount > 0, "[quantity] must be positive");
-    check( escrow_itr->ext_asset.quantity.amount != 0, "`escrow_name` has already been filled");
+    check( escrow_itr->ext_asset.quantity.amount == 0, "`escrow_name` has already been filled (multiple deposits are not allowed)");
 
     // fill escrow quantity with transfer deposit
     escrows.modify(escrow_itr, get_self(), [&](auto & row) {


### PR DESCRIPTION
## New Features 💥 
- Allow multiple escrows to be created by sender (https://github.com/boscore/referendum/commit/ff249c8799597feba3b54686c406483deb626adb)
- Allow any `sender` & `approver` to initialize an escrow (previously only `bet.bos` & `eosio`) (https://github.com/boscore/referendum/commit/6c4d79a27b0ed14a83a6138a27ce50ecf6ac677b)

### Tests - `transfer` BOS with `memo`

- [x] `memo` must be provided
- [x] `memo` must match `escrow_name`
- [x] `from` must match `sender` of `escrow_name`
- [x] escrow must be empty (multiple deposits are not allowed)

### Tests - `init` ACTION

- [x] allow multiple unfilled/unique escrows to be created by a sender (create two escrows with a unique account)

### BOS Testnet

Contract deployed: https://bos-test.bloks.io/account/escrow.bos